### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete multi-character sanitization

### DIFF
--- a/index.html
+++ b/index.html
@@ -2640,10 +2640,8 @@
     function speakText(text, options = {}) {
         if (!GameState.settings.audioDescriptions || !('speechSynthesis' in window)) return;
         
-        // Convert potential HTML input into plain text safely
-        const tempDiv = document.createElement('div');
-        tempDiv.innerHTML = String(text ?? '');
-        const cleanText = (tempDiv.textContent || tempDiv.innerText || '').replace(/\s+/g, ' ').trim();
+        // Normalize input as plain text without interpreting it as HTML
+        const cleanText = String(text ?? '').replace(/\s+/g, ' ').trim();
         
         if (cleanText.length === 0) return;
         

--- a/index.html
+++ b/index.html
@@ -2640,10 +2640,12 @@
     function speakText(text, options = {}) {
         if (!GameState.settings.audioDescriptions || !('speechSynthesis' in window)) return;
         
-        // Clean HTML tags from text
-        const cleanText = text.replace(/<[^>]*>/g, '').replace(/&[^;]+;/g, ' ');
+        // Convert potential HTML input into plain text safely
+        const tempDiv = document.createElement('div');
+        tempDiv.innerHTML = String(text ?? '');
+        const cleanText = (tempDiv.textContent || tempDiv.innerText || '').replace(/\s+/g, ' ').trim();
         
-        if (cleanText.trim().length === 0) return;
+        if (cleanText.length === 0) return;
         
         const utterance = new SpeechSynthesisUtterance(cleanText);
         utterance.rate = options.rate || 1;


### PR DESCRIPTION
Potential fix for [https://github.com/DDriftz/Synapse-RootAccessDenied/security/code-scanning/1](https://github.com/DDriftz/Synapse-RootAccessDenied/security/code-scanning/1)

Use a parser-based approach instead of regex-based multi-character stripping. The safest no-dependency fix in-browser is to parse the input as HTML via a detached element and extract plain text with `textContent`. This avoids iterative regex pitfalls and handles malformed markup robustly.

**Change location:** `index.html`, inside `speakText` around line 2643–2645.

**What to change:**
- Replace:
  - `text.replace(/<[^>]*>/g, '').replace(/&[^;]+;/g, ' ')`
- With:
  - Create a temporary element (`document.createElement('div')`)
  - Set `tempDiv.innerHTML = String(text ?? '')`
  - Read plain text via `tempDiv.textContent || tempDiv.innerText || ''`
  - Optionally normalize whitespace for better speech output

No new imports or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
