### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -2972,6 +2972,21 @@
         return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     }
 
+    // Utility function to escape HTML special characters in text nodes
+    function escapeHTML(string) {
+        return String(string)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    // Utility function to escape HTML attribute values
+    function escapeHTMLAttribute(string) {
+        return escapeHTML(string);
+    }
+
     async function typeWriter(element, text, color = 'var(--main-color)', speed = currentTextSpeed) {
         const resolvedColor = color.startsWith('var(') ? getComputedStyle(document.documentElement).getPropertyValue(color.slice(4, -1)).trim() : color;
         
@@ -2988,7 +3003,7 @@
         
         // Create a regex to find all known item names as whole words
         const objectRegex = new RegExp(`\\b(${(Object.keys(itemData)).map(escapeRegExp).join('|')})\\b`, 'gi');
-        let processedText = text.replace(objectRegex, (match) => `<span class="clickable-object" data-object-name="${match}">${match}</span>`);
+        let processedText = escapeHTML(text).replace(objectRegex, (match) => `<span class="clickable-object" data-object-name="${escapeHTMLAttribute(match)}">${escapeHTML(match)}</span>`);
 
         return new Promise(resolve => {
             const MAX_OUTPUT_NODES = 100; // Limit output lines to prevent performance issues
@@ -3000,8 +3015,8 @@
             function typing() {
                 if (i < text.length) {
                     if(speed > 0) playSound('typewriter');
-                    // Use the original text for the animation, then set the processed HTML at the end
-                    p.innerHTML = text.substring(0, i + 1);
+                    // Use safe text rendering for the animation, then set the processed HTML at the end
+                    p.textContent = text.substring(0, i + 1);
                     i++;
                     element.scrollTop = element.scrollHeight;
                     setTimeout(typing, speed);


### PR DESCRIPTION
Potential fix for [https://github.com/DDriftz/Synapse-RootAccessDenied/security/code-scanning/3](https://github.com/DDriftz/Synapse-RootAccessDenied/security/code-scanning/3)

Use safe text rendering for the typewriter animation, and only use HTML insertion with properly escaped dynamic content for the final clickable-object rendering.

Best fix in this snippet:
1. **Line region around 3004**: replace `p.innerHTML = text.substring(0, i + 1);` with `p.textContent = text.substring(0, i + 1);` so intermediate typed text is never parsed as HTML.
2. **Line region around 2991**: ensure both the displayed match text and `data-object-name` attribute are escaped before constructing span HTML. Add small helper escape functions in `index.html` near existing utilities (after `escapeRegExp` is a good place).
3. Keep final `p.innerHTML = processedText` for clickable spans functionality, but make `processedText` safe by escaping non-matched text and matched values.

This preserves functionality (typing animation + clickable objects) without changing behavior beyond neutralizing HTML/script injection.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
