### PR TITLE
Potential fix for code scanning alert no. 8: DOM text reinterpreted as HTML

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -46,6 +46,15 @@ export function updateUIText(language = 'en') {
     });
 }
 
+function escapeHTML(value) {
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
 // Modal Management
 export function showModal(content, title = '', buttons = [], options = {}) {
     const modal = document.getElementById('modal');
@@ -58,20 +67,24 @@ export function showModal(content, title = '', buttons = [], options = {}) {
         hideModal();
     }
     
+    const safeTitle = escapeHTML(title);
+    const safeContent = escapeHTML(content);
     let html = '<div class="modal-inner">';
     
     if (title) {
-        html += `<h2 class="text-2xl font-bold mb-4 text-cyan-400 glitch" data-text="${title}">${title}</h2>`;
+        html += `<h2 class="text-2xl font-bold mb-4 text-cyan-400 glitch" data-text="${safeTitle}">${safeTitle}</h2>`;
     }
     
-    html += `<div class="modal-body mb-4 ${options.scrollable ? 'modal-scroll max-h-[60vh]' : ''}">${content}</div>`;
+    html += `<div class="modal-body mb-4 ${options.scrollable ? 'modal-scroll max-h-[60vh]' : ''}">${safeContent}</div>`;
     
     if (buttons.length > 0) {
         html += '<div class="modal-buttons flex gap-2 justify-center flex-wrap">';
         buttons.forEach((btn, index) => {
             const btnClass = btn.primary ? 'button-primary' : '';
             const btnId = `modal-btn-${index}`;
-            html += `<button id="${btnId}" class="button btn-glow btn-drip ${btnClass} ${btn.class || ''}">${btn.text}</button>`;
+            const safeBtnClass = escapeHTML(btn.class || '');
+            const safeBtnText = escapeHTML(btn.text || '');
+            html += `<button id="${btnId}" class="button btn-glow btn-drip ${btnClass} ${safeBtnClass}">${safeBtnText}</button>`;
         });
         html += '</div>';
     }


### PR DESCRIPTION
Potential fix for [https://github.com/DDriftz/Synapse-RootAccessDenied/security/code-scanning/8](https://github.com/DDriftz/Synapse-RootAccessDenied/security/code-scanning/8)

Use contextual escaping before concatenating dynamic values into HTML in `showModal` (`js/ui.js`), so that any attacker-controlled text is rendered as text, not executable markup.

Best practical fix here (without redesigning modal rendering) is:

1. Add a small HTML-escape helper in `js/ui.js`.
2. Escape `title`, `content`, button class names, and button text before interpolation.
3. Keep `innerHTML` usage for the modal template itself so existing modal layout/behavior remains intact.

This addresses all reported variants because they all converge in `showModal(...)` at `modalContent.innerHTML = html;`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
