### PR TITLE
Potential fix for code scanning alert no. 9: DOM text reinterpreted as HTML

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -864,25 +864,13 @@ export function typewriterEffect(text, element, callback, speed = 30) {
     if (!element || UIState.typewriterActive) return;
     
     UIState.typewriterActive = true;
-    element.innerHTML = '';
+    element.textContent = '';
     let index = 0;
     
     function type() {
         if (index < text.length) {
-            // Check for HTML tags
-            if (text[index] === '<') {
-                const tagEnd = text.indexOf('>', index);
-                if (tagEnd !== -1) {
-                    element.innerHTML += text.substring(index, tagEnd + 1);
-                    index = tagEnd + 1;
-                } else {
-                    element.innerHTML += text[index];
-                    index++;
-                }
-            } else {
-                element.innerHTML += text[index];
-                index++;
-            }
+            element.textContent += text[index];
+            index++;
             
             // Variable speed for punctuation
             let delay = speed;


### PR DESCRIPTION
Potential fix for [https://github.com/DDriftz/Synapse-RootAccessDenied/security/code-scanning/9](https://github.com/DDriftz/Synapse-RootAccessDenied/security/code-scanning/9)

Use text-only rendering in the typewriter function so untrusted input is never reinterpreted as HTML.

Best single fix (without changing broader functionality beyond unsafe HTML parsing):
- Edit `js/ui.js`, in `typewriterEffect`.
- Replace `element.innerHTML = ''` with `element.textContent = ''`.
- Remove the HTML-tag parsing branch and append one character at a time using `element.textContent += ...`.
- Keep timing/punctuation/callback behavior unchanged.

This addresses all listed variants because they all converge on the same sink in `typewriterEffect`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
