### PR TITLE
Potential fix for code scanning alert no. 14: DOM text reinterpreted as HTML

### DIFF
--- a/robust-init.js
+++ b/robust-init.js
@@ -1023,8 +1023,18 @@ function handleBasicCommand(command) {
     const gameOutput = document.getElementById('game-output');
     if (gameOutput) {
         const response = getBasicResponse(command);
-        gameOutput.innerHTML += `<div style="color: #0ff;">>${command}</div>`;
-        gameOutput.innerHTML += `<div style="color: #fff;">${response}</div><br>`;
+
+        const commandDiv = document.createElement('div');
+        commandDiv.style.color = '#0ff';
+        commandDiv.textContent = `>${command}`;
+
+        const responseDiv = document.createElement('div');
+        responseDiv.style.color = '#fff';
+        responseDiv.textContent = response;
+
+        gameOutput.appendChild(commandDiv);
+        gameOutput.appendChild(responseDiv);
+        gameOutput.appendChild(document.createElement('br'));
         gameOutput.scrollTop = gameOutput.scrollHeight;
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/DDriftz/Synapse-RootAccessDenied/security/code-scanning/14](https://github.com/DDriftz/Synapse-RootAccessDenied/security/code-scanning/14)

Best fix: stop using `innerHTML` for untrusted content, and render user text with `textContent` (or `createTextNode`) so it is treated as text, not HTML.

In `robust-init.js`, update `handleBasicCommand` (lines 1022–1029 region) to:
- Create `<div>` elements with `document.createElement`.
- Set style via `.style.color`.
- Set displayed content via `.textContent` for both command and response.
- Append nodes with `appendChild`.
- Add spacing with a `<br>` node (or CSS margin), preserving current behavior.

No new imports or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
