### PR TITLE
Potential fix for code scanning alert no. 17: DOM text reinterpreted as HTML

### DIFF
--- a/robust-init.js
+++ b/robust-init.js
@@ -265,8 +265,6 @@ function updateAbilityDisplay() {
     const selectedBackstory = backstorySelect.value;
     const selectedPhobia = phobiaSelect.value;
     
-    let displayText = '';
-    
     // Backstory descriptions
     const backstoryInfo = {
         investigator: { name: 'Investigator', desc: 'Former detective with keen observation skills', skills: ['perception', 'logic', 'interrogation'] },
@@ -281,11 +279,27 @@ function updateAbilityDisplay() {
         skeptic: { name: 'Skeptic', desc: 'Refuses to believe in the supernatural', skills: ['rationality', 'doubt', 'debunking'] }
     };
     
+    // Clear previous content safely
+    abilityDisplay.textContent = '';
+    let hasContent = false;
+    
     // Show backstory info
     if (selectedBackstory && selectedBackstory !== 'random' && backstoryInfo[selectedBackstory]) {
         const backstory = backstoryInfo[selectedBackstory];
-        displayText += `<strong>${backstory.name}:</strong> ${backstory.desc}<br>`;
-        displayText += `<em>Skills:</em> ${backstory.skills.join(', ')}<br>`;
+        
+        const backstoryStrong = document.createElement('strong');
+        backstoryStrong.textContent = `${backstory.name}:`;
+        abilityDisplay.appendChild(backstoryStrong);
+        abilityDisplay.appendChild(document.createTextNode(` ${backstory.desc}`));
+        abilityDisplay.appendChild(document.createElement('br'));
+        
+        const skillsEm = document.createElement('em');
+        skillsEm.textContent = 'Skills:';
+        abilityDisplay.appendChild(skillsEm);
+        abilityDisplay.appendChild(document.createTextNode(` ${backstory.skills.join(', ')}`));
+        abilityDisplay.appendChild(document.createElement('br'));
+        
+        hasContent = true;
     }
     
     // Show phobia info
@@ -303,15 +317,19 @@ function updateAbilityDisplay() {
             death: 'Death (Thanatophobia)'
         };
         
-        if (displayText) displayText += '<br>';
-        displayText += `<strong>Phobia:</strong> ${phobiaNames[selectedPhobia] || selectedPhobia}`;
+        if (hasContent) abilityDisplay.appendChild(document.createElement('br'));
+        
+        const phobiaStrong = document.createElement('strong');
+        phobiaStrong.textContent = 'Phobia:';
+        abilityDisplay.appendChild(phobiaStrong);
+        abilityDisplay.appendChild(document.createTextNode(` ${phobiaNames[selectedPhobia] || selectedPhobia}`));
+        
+        hasContent = true;
     }
     
-    if (!displayText) {
-        displayText = 'Select your backstory and phobia to see character details';
+    if (!hasContent) {
+        abilityDisplay.textContent = 'Select your backstory and phobia to see character details';
     }
-    
-    abilityDisplay.innerHTML = displayText;
 }
 
 function setupLanguageButtons() {


### PR DESCRIPTION
Potential fix for [https://github.com/DDriftz/Synapse-RootAccessDenied/security/code-scanning/17](https://github.com/DDriftz/Synapse-RootAccessDenied/security/code-scanning/17)

The safest fix without changing user-visible functionality is to **stop writing untrusted strings via `innerHTML`** and instead build the output using DOM nodes with `textContent` for dynamic text. This preserves formatting (`<strong>`, `<em>`, `<br>`) while ensuring any attacker-controlled value is treated as text, not HTML.

In `robust-init.js`, update `updateAbilityDisplay()`:
- Replace string assembly (`displayText`) with structured rendering into `abilityDisplay`.
- Clear existing content safely (`abilityDisplay.textContent = ''`).
- Create elements (`strong`, `em`, text nodes, and `br`) and append them.
- Keep the same logic and fallback message.

No new imports or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
