### PR TITLE
Potential fix for code scanning alert no. 18: DOM text reinterpreted as HTML

### DIFF
--- a/robust-init.js
+++ b/robust-init.js
@@ -785,7 +785,9 @@ function showPhobiasModal() {
 
 function getCurrentDifficulty() {
     const difficultyBtn = document.querySelector('.difficulty-btn.button-primary');
-    return difficultyBtn ? difficultyBtn.getAttribute('data-difficulty') : 'Normal';
+    const rawDifficulty = difficultyBtn ? difficultyBtn.getAttribute('data-difficulty') : null;
+    const allowedDifficulties = ['Easy', 'Normal', 'Hard'];
+    return allowedDifficulties.includes(rawDifficulty) ? rawDifficulty : 'Normal';
 }
 
 function getItemsByDifficulty(baseItems, bonusItems, difficulty) {


### PR DESCRIPTION
Potential fix for [https://github.com/DDriftz/Synapse-RootAccessDenied/security/code-scanning/18](https://github.com/DDriftz/Synapse-RootAccessDenied/security/code-scanning/18)

The best fix is to **validate and normalize `difficulty` to a strict allowlist** before it is ever interpolated into HTML. This preserves existing functionality while preventing attacker-controlled markup from reaching `innerHTML`.

In `robust-init.js`, update `getCurrentDifficulty()` (lines 786–789 region) to:
- read the attribute as today,
- allow only known values (`Easy`, `Normal`, `Hard`),
- fallback to `'Normal'` for anything else.

This is the minimal, behavior-preserving mitigation for the reported dataflow path. No additional imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
