### PR TITLE
Potential fix for code scanning alert no. 20: DOM text reinterpreted as HTML

### DIFF
--- a/begin-button-fix.js
+++ b/begin-button-fix.js
@@ -285,7 +285,10 @@ function processPlayerCommand(command) {
     
     const commandDiv = document.createElement('div');
     commandDiv.className = 'mb-2';
-    commandDiv.innerHTML = `<span class="text-cyan-400">&gt; ${command}</span>`;
+    const commandSpan = document.createElement('span');
+    commandSpan.className = 'text-cyan-400';
+    commandSpan.textContent = `> ${command}`;
+    commandDiv.appendChild(commandSpan);
     gameOutput.appendChild(commandDiv);
     
     // Basic command processing with translation support


### PR DESCRIPTION
Potential fix for [https://github.com/DDriftz/Synapse-RootAccessDenied/security/code-scanning/20](https://github.com/DDriftz/Synapse-RootAccessDenied/security/code-scanning/20)

To fix this safely, avoid interpreting user input as HTML. The best approach here is to build DOM nodes and assign untrusted text using `textContent`, while keeping the same visual behavior.

In `begin-button-fix.js`, inside `processPlayerCommand` (around lines 286–289), replace the `innerHTML` assignment with:
- creation of a `<span>`
- applying the same class (`text-cyan-400`)
- setting `span.textContent = \`> ${command}\``
- appending the span to `commandDiv`

This preserves functionality and styling, removes the XSS sink, and requires no new imports or dependencies.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
